### PR TITLE
Update train.py

### DIFF
--- a/detection/train.py
+++ b/detection/train.py
@@ -89,13 +89,13 @@ def parse_args():
                         choices=['none', 'pytorch', 'slurm', 'mpi'],
                         default='none',
                         help='job launcher')
-    parser.add_argument('--local_rank', type=int, default=0)
+    parser.add_argument('--local-rank', type=int, default=0)
     parser.add_argument('--auto-scale-lr',
                         action='store_true',
                         help='enable automatically scaling LR.')
     args = parser.parse_args()
     if 'LOCAL_RANK' not in os.environ:
-        os.environ['LOCAL_RANK'] = str(args.local_rank)
+        os.environ['LOCAL_RANK'] = str(getattr(args, "local-rank"))
 
     if args.options and args.cfg_options:
         raise ValueError(
@@ -193,8 +193,7 @@ def main():
     env_info_dict = collect_env()
     env_info = '\n'.join([(f'{k}: {v}') for k, v in env_info_dict.items()])
     dash_line = '-' * 60 + '\n'
-    logger.info('Environment info:\n' + dash_line + env_info + '\n' +
-                dash_line)
+    logger.info('Environment info:\n' + dash_line + env_info + '\n' + dash_line)
     meta['env_info'] = env_info
     meta['config'] = cfg.pretty_text
     # log some basic info


### PR DESCRIPTION
Running the orignial train.py with dist_train.sh will lead to the error: `unrecognized arguments: --local_rank=0` on pytorch 2. This edit will fix the error.